### PR TITLE
Test drive front-page and template

### DIFF
--- a/testdrive/README.md
+++ b/testdrive/README.md
@@ -65,3 +65,7 @@ To keep things simple some simplifying assumptions are made:
 
 ## Creating a new Test Drive Program
 
+1. Create a new subdirectory under this one named for the package manager you are adding.
+2. Copy the [README template](TestDriveREADMETemplate.md) into the new directory and fill in the details
+   noted by the _**Authors**_ _: add details here..._ comments.
+

--- a/testdrive/README.md
+++ b/testdrive/README.md
@@ -1,8 +1,67 @@
-Packaging Working Group - Test Drive Area
-=========================================
+# Packaging Working Group - Test Drive Area
 
-This directory holds documentation and files for the test drive
-of HEP packages in the packaging group *test stack* in order to
-evaluate the various *use cases* identified. 
+This directory holds documentation and files for test driving various package manager tools
+to demonstrate the installation and use a [HEP test stack](#hep-test-stack) in order to
+evaluate the various [identified use cases](https://docs.google.com/document/d/1h-r3XPIXXxmr5tThIh6gu6VcXXRhBXtUuOv14ju3oTI/).
+We currently have test drives for:
 
-There is one directory for the evaluation of each tool.
+- [nix](nix)
+- [portage](portage)
+- [spack](spack)
+
+See the READMEs in each directories for more details on the tool and instructions for taking it for a test drive.
+If you want to create a test drive for a new package manager, please see the information below.
+
+
+## HEP Test Stack
+
+From discussions in [HSF Packaging Meeting #14](https://indico.cern.ch/event/678307/), a minimal subset of packages
+was identified to exercise the package managers with:
+
+- **Toolchain**
+  - GCC 6.4
+    - With c, c++, fortran languages
+  - Python 2.7.14
+  - _Plus any packages required to build and run the above_
+- **Core HEP Stack**
+  - Boost 1.65
+  - ROOT 6.12.06
+    - Including PyROOT, MathMore
+  - GSL 2.4
+  - Qt5 5.10 (`qtbase` only)
+  - Xerces-C 3.1.4
+  - CLHEP (_Version to be compatible with Geant4_)
+  - Geant4 10.3
+  - _Plus any packages required to build and run the above_
+
+## HEP Stack Test Drive Program
+
+To enable to WG (and eventually the broader HEP community) to evaluate how well a given package manager solves the [identified use cases](https://docs.google.com/document/d/1h-r3XPIXXxmr5tThIh6gu6VcXXRhBXtUuOv14ju3oTI/) as well as general considerations such as portability and ease of use, a basic list of tasks is outlined to provide a template for "driving lessons" on:
+
+- Installing the package manager
+- Installing the first package
+- Installing the HEP Test Stack
+- Using installed packages
+- Adding new packages
+- Developing software against installed packages
+
+To keep things simple some simplifying assumptions are made:
+
+- [Docker](https://www.docker.com) images are used for testing Linux platforms.
+
+  This is purely for consistency and reproducibility, and does not suggest that containers will be the only way to
+  use a given package manager! It also helps to enumerate the OS packages that are always needed by the package manager.
+
+- No use of [CVMFS](https://cernvm.cern.ch/portal/filesystem) is assumed yet.
+
+  This is to ensure that test drivers get a feel for building from source,
+  installing from binary, writing packages for their own software, and the balance between reuse of OS
+  packages vs “compile the world”.
+
+  It does not imply that CVMFS will not be used later, but users will have to go through the packaging steps to have
+  something to deploy to CVMFS! Smaller experiments may also not have access to CVMFS.
+
+- The test driver may have `sudo` access, but the steps requiring this should be minimized and ideally zero.
+
+## Creating a new Test Drive Program
+

--- a/testdrive/TestDriveREADMETemplate.md
+++ b/testdrive/TestDriveREADMETemplate.md
@@ -1,0 +1,75 @@
+# Test Driving the Foo Package Manager 
+
+_**AUTHORS:**_ _Change "Foo" here and elsewhere in the template to the name of the package manager_
+
+This document will walk you through preparing and using the Foo (_**AUTHORS:**_ _Provide a link to the tool's home page_)
+package manager to install a basic software stack for HEP. 
+
+Foo is ...
+
+_**AUTHORS:**_ _Provide a brief description of Foo and what is good about it, defer to the tool's own docs if preferred!_
+
+
+
+## Base Operating System Install
+
+_**AUTHORS:**_ _Assume a base system of macOS High Sierra with Xcode 9, or a Docker Image based on centos:centos7 or 
+ubuntu:xenial. In the Docker case, supply (a) Dockerfile(s) for each system, adding any additional system packages 
+required, and (b) an `hsf` user with `sudo` privileges that the container will run as. There’s no requirement 
+to build and host the images. Bonus points: Singularity! If macOS needs additional packages, document them below:_
+
+Test driving Foo requires either a CentOS6/7, Ubuntu 16.04LTS, or macOS High Sierra system. For macOS, only the base system 
+plus Xcode 9 from the App Store (_**AUTHORS:**_ _add any additional requirements here_) is required. For convenience and 
+reproducibility, Docker images are available for Linux, and can be obtained and run as follows:
+
+_**AUTHORS:**_ _Add Docker pull/build/run instructions here_
+
+Optionally, you may use an existing Linux installation, but you may encounter errors in subsequent steps if it is missing 
+(or has incompatible) packages, or your environment has custom settings.
+
+## Installing Foo
+To install Foo, ...
+
+_**AUTHORS:**_ _Add instructions here. Aim should be to get Foo up and running in the most minimal way
+possible. Include a set of test/sanity checks and install of a "hello world" package like `zlib` if the 
+packages manager allows. In both cases, reuse/link to the tool's own documentation if you think it's clear enough_
+
+## Installing the HEP Test Stack
+The HSF Test Stack packages are as follows:
+
+- **Toolchain**
+  - GCC 6.4 
+    - With c, c++, fortran languages
+  - Python 2.7.14
+- **Core HEP Stack**
+  - Boost 1.65
+  - ROOT 6.12.06 
+    - Including PyROOT, MathMore
+  - GSL 2.4
+  - Qt5 5.10 (`qtbase` only)
+  - Xerces-C 3.1.4
+  - CLHEP (_Version to be compatible with Geant4_)
+  - Geant4 10.3
+
+To install this stack, ...
+
+_**AUTHORS:**_ _Document the steps needed to install these packages from source, and separately from 
+binary if the tool provides these_ 
+
+Optionally, ...
+
+_**AUTHORS:**_ _Show any other features of the tool you think are useful here, e.g. build using different C++ Standards,
+optional components of packages, different package versions_
+
+# Using the HEP Test Stack
+To use the freshly installed test stack, ...
+
+_**AUTHORS:**_ _Document the steps needed to setup a runtime environment for using
+the stack listed above, including optional parts if the tools allows this_
+
+# Adding a New Package to the Stack
+To add a new package to the stack, ...
+
+_**AUTHORS:**_ _Document the steps needed to create a package for a simple C/C++
+library or application (your choice) and walkthrough the steps to build and install it. Reuse/link to the tool's
+own documentation on this if you think it's sufficient_


### PR DESCRIPTION
This copies details from the original WG Google Doc on packaging to the subproject's README, covering:

- Basic ideas
- Stack packages/versions at time of writing
- Current available test drives

The template for a README that new test drives should fill out/extend as required is also drafted.

Still a WIP, and should wait for, and be rebased on #9