### PR TITLE
Add missing package (which) to the Spack Dockerfile image 

### DIFF
--- a/testdrive/spack/c7-spack/Dockerfile
+++ b/testdrive/spack/c7-spack/Dockerfile
@@ -28,7 +28,8 @@ RUN yum update -y               && \
         patch                 \
         openssh-server        \
         python                \
-        tcl                && \
+        tcl                   \
+        which              && \
     git clone --depth 1 git://github.com/spack/spack.git /spack && \
     rm -rf /spack/.git
 


### PR DESCRIPTION
`qt` installation fails on the current image since `which` is not installed

This PR adds `which` to the Dockerfile for the Spack testdrive.
- The corresponding image in Dockerhub will be also updated.