### PR TITLE
Nix improvements

### DIFF
--- a/testdrive/nix/c7-nix/Dockerfile
+++ b/testdrive/nix/c7-nix/Dockerfile
@@ -38,4 +38,4 @@ RUN nix-env -ir -f /home/hsf/testdrive_environment.nix -A env
 # For deployment we could either:
 #    - source a script to initialise an identical environment
 #    - add support for discovering the install location (multiple options are available)
-CMD ["nix-shell" "--pure" "/home/hsf/testdrive_environment.nix"]
+CMD ["nix-shell", "--pure", "/home/hsf/testdrive_environment.nix"]

--- a/testdrive/nix/c7-nix/Dockerfile
+++ b/testdrive/nix/c7-nix/Dockerfile
@@ -27,11 +27,59 @@ ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
 
 # Change from the default unstable channel to 18.03 (last release, April 2018)
 RUN nix-channel --remove nixpkgs
-RUN nix-channel --add https://nixos.org/channels/nixos-18.03 nixos
+RUN nix-channel --add https://nixos.org/channels/nixos-18.03 nixpkgs
 RUN nix-channel --update
 
 # Now install a few basic nix packages, as a development bootstrap
-RUN nix-env -i gcc boost cmake python
+RUN nix-env -i -f '<nixpkgs>' \
+    -A autoconf \
+    -A automake \
+    -A bashInteractive \
+    -A bzip2 \
+    -A cmake \
+    -A coreutils \
+    -A cpio \
+    -A cracklib \
+    -A curl \
+    -A diffutils \
+    -A ed \
+    -A elfutils \
+    -A expat \
+    -A findutils \
+    -A gawk \
+    -A gcc \
+    -A git \
+    -A gnugrep \
+    -A gnumake \
+    -A gnused \
+    -A gzip \
+    -A less \
+    -A man \
+    -A pcre \
+    -A perl \
+    -A python \
+    -A rsync \
+    -A strace \
+    -A tcl \
+    -A vim \
+    -A wget \
+    -A which \
+    -A xz \
+    -A zlib \
+    -A zsh
 
-ENTRYPOINT ["bash"]
+# Install the toolchain
+RUN nix-env -i -f '<nixpkgs>' \
+    -A boost166 \
+    -A gsl \
+    -A qt510.qtbase \
+    -A root \
+    -A xercesc
+
+# For now the upstream GEANT4 recipe is a little weird but it seems like someone is working on it:
+# https://github.com/NixOS/nixpkgs/pull/40618
+# As it is badly written it isn't available in the binary cache so this will trigger a build
+RUN nix-env -i -f '<nixpkgs>' -A geant4.v10_0_2
+
+ENTRYPOINT ["/home/hsf/.nix-profile/bin/bash"]
 CMD ["-l"]

--- a/testdrive/nix/c7-nix/Dockerfile
+++ b/testdrive/nix/c7-nix/Dockerfile
@@ -1,5 +1,4 @@
 # Install nix into a base CentOS7 image
-
 FROM centos:7
 LABEL maintainer="Graeme Stewart <graeme.andrew.stewart@cern.ch>"
 
@@ -11,75 +10,32 @@ RUN yum -y install curl bzip2 sudo
 RUN useradd -G wheel -p '$6$JmsT1xYM$CdWIKb6aHhqWniaanWDq1Hi9qF4pXJlmsSHrqDDjF8CsYG3w8WyTO4/.xBnG71Zx1aROZ.S.ZoR2BARuB4QBN1' hsf
 COPY sudoers /etc/suoders
 # Pre-create the /nix area because here we install as a single user
-RUN mkdir -m 0755 /nix
-RUN chown hsf /nix
+RUN mkdir -m 0755 /nix && chown hsf /nix
 USER hsf
-ENV USER=hsf
-ENV HOME=/home/hsf
+ENV USER=hsf \
+    HOME=/home/hsf
 WORKDIR /home/hsf
-RUN curl -O https://nixos.org/nix/install
-RUN bash < install
+RUN curl https://nixos.org/nix/install | bash
 
-# Bootstrap the nix environment 
-ENV PATH=/home/hsf/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/hsf/.local/bin:/home/hsf/bin
-ENV NIX_PATH=nixpkgs=/home/hsf/.nix-defexpr/channels/nixpkgs
-ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+# Bootstrap the nix environment
+ENV PATH=/home/hsf/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/hsf/.local/bin:/home/hsf/bin \
+    NIX_PATH=nixpkgs=/home/hsf/.nix-defexpr/channels/nixpkgs \
+    NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
 
 # Change from the default unstable channel to 18.03 (last release, April 2018)
-RUN nix-channel --remove nixpkgs
-RUN nix-channel --add https://nixos.org/channels/nixos-18.03 nixpkgs
-RUN nix-channel --update
+RUN nix-channel --remove nixpkgs && \
+    nix-channel --add https://nixos.org/channels/nixos-18.03 nixpkgs && \
+    nix-channel --update
 
-# Now install a few basic nix packages, as a development bootstrap
-RUN nix-env -i -f '<nixpkgs>' \
-    -A autoconf \
-    -A automake \
-    -A bashInteractive \
-    -A bzip2 \
-    -A cmake \
-    -A coreutils \
-    -A cpio \
-    -A cracklib \
-    -A curl \
-    -A diffutils \
-    -A ed \
-    -A elfutils \
-    -A expat \
-    -A findutils \
-    -A gawk \
-    -A gcc \
-    -A git \
-    -A gnugrep \
-    -A gnumake \
-    -A gnused \
-    -A gzip \
-    -A less \
-    -A man \
-    -A pcre \
-    -A perl \
-    -A python \
-    -A rsync \
-    -A strace \
-    -A tcl \
-    -A vim \
-    -A wget \
-    -A which \
-    -A xz \
-    -A zlib \
-    -A zsh
+# Use a nix expression to define the environment
+COPY testdrive_environment.nix /home/hsf/testdrive_environment.nix
 
-# Install the toolchain
-RUN nix-env -i -f '<nixpkgs>' \
-    -A boost166 \
-    -A gsl \
-    -A qt510.qtbase \
-    -A root \
-    -A xercesc
+# Install the test drive environment in the default location
+RUN nix-env -ir -f /home/hsf/testdrive_environment.nix -A env
 
-# For now the upstream GEANT4 recipe is a little weird but it seems like someone is working on it:
-# https://github.com/NixOS/nixpkgs/pull/40618
-# As it is badly written it isn't available in the binary cache so this will trigger a build
-RUN nix-env -i -f '<nixpkgs>' -A geant4.v10_0_2
-
-ENTRYPOINT ["/home/hsf/.nix-profile/bin/bash"]
-CMD ["-l"]
+# By default launch the test drive environment using nix shell
+# This sets up the environment variables which is the "official" way of using Nix
+# For deployment we could either:
+#    - source a script to initialise an identical environment
+#    - add support for discovering the install location (multiple options are available)
+CMD ["nix-shell" "--pure" "/home/hsf/testdrive_environment.nix"]

--- a/testdrive/nix/c7-nix/Dockerfile
+++ b/testdrive/nix/c7-nix/Dockerfile
@@ -38,4 +38,4 @@ RUN nix-env -ir -f /home/hsf/testdrive_environment.nix -A env
 # For deployment we could either:
 #    - source a script to initialise an identical environment
 #    - add support for discovering the install location (multiple options are available)
-CMD ["nix-shell", "--pure", "/home/hsf/testdrive_environment.nix"]
+CMD ["nix-shell", "--pure", "--command", "export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt; return", "/home/hsf/testdrive_environment.nix"]

--- a/testdrive/nix/c7-nix/Dockerfile
+++ b/testdrive/nix/c7-nix/Dockerfile
@@ -11,6 +11,13 @@ RUN useradd -G wheel -p '$6$JmsT1xYM$CdWIKb6aHhqWniaanWDq1Hi9qF4pXJlmsSHrqDDjF8C
 COPY sudoers /etc/suoders
 # Pre-create the /nix area because here we install as a single user
 RUN mkdir -m 0755 /nix && chown hsf /nix
+
+# Copy a nix expression that is used to define the environment
+COPY testdrive_environment.nix clhep.nix /home/hsf/
+# COPY geant4 /home/hsf/geant4
+RUN chown -R hsf /home/hsf && chgrp -R hsf /home/hsf
+
+# Install nix
 USER hsf
 ENV USER=hsf \
     HOME=/home/hsf
@@ -26,9 +33,6 @@ ENV PATH=/home/hsf/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/us
 RUN nix-channel --remove nixpkgs && \
     nix-channel --add https://nixos.org/channels/nixos-18.03 nixpkgs && \
     nix-channel --update
-
-# Use a nix expression to define the environment
-COPY testdrive_environment.nix /home/hsf/testdrive_environment.nix
 
 # Install the test drive environment in the default location
 RUN nix-env -ir -f /home/hsf/testdrive_environment.nix -A env

--- a/testdrive/nix/c7-nix/clhep.nix
+++ b/testdrive/nix/c7-nix/clhep.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit, cmake }:
+
+let
+  version = "2.1.3.1";
+  name = "clhep-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchgit {
+    url = "https://gitlab.cern.ch/CLHEP/CLHEP.git";
+    rev = "45ad2464329e4495b61b733a1cd95debefda411a";
+    sha256 = "16wr28bprj4l93fr1q9b9ycvqi4a6jx7ynmh2wv0m65rcr0wmhrq";
+  };
+
+  buildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+  # This isn't needed for newer versions of CLHEP
+  dontFixCmake = true;
+  dontUseCmakeBuildDir = true;
+  preConfigure = ''
+    fixCmakeFiles .
+    mkdir -p ../build
+    cmakeDir="$PWD"
+    cd ../build
+  '';
+
+  meta = {
+    homepage = https://proj-clhep.web.cern.ch/proj-clhep/;
+    description = "A Class Library for High Energy Physics";
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/testdrive/nix/c7-nix/testdrive_environment.nix
+++ b/testdrive/nix/c7-nix/testdrive_environment.nix
@@ -1,0 +1,75 @@
+{ nixpkgs ? <nixpkgs> }:
+
+with import nixpkgs {};
+
+stdenv.mkDerivation rec {
+  name = "HSF_testdrive_environment";
+  env = buildEnv {
+    name = name;
+    paths = buildInputs;
+    extraOutputsToInstall = [
+      "bin" "debug" "dev" "devdoc" "doc" "info" "man" "out" "static"
+    ];
+  };
+  buildInputs = [
+    # Nix itself
+    nix
+
+    # Some base libraries
+    autoconf
+    automake
+    bash
+    bashInteractive
+    bzip2
+    cmake
+    coreutils
+    cpio
+    cracklib
+    curl
+    diffutils
+    ed
+    elfutils
+    emacs
+    expat
+    findutils
+    fish
+    gawk
+    gcc
+    git
+    gnugrep
+    gnumake
+    gnused
+    gnutar
+    gzip
+    htop
+    less
+    man
+    patchelf
+    pcre
+    perl
+    procps
+    python
+    rsync
+    stdenv
+    strace
+    tcl
+    vim
+    wget
+    which
+    xz
+    zlib
+    zsh
+
+    # The test drive packages
+    boost166
+    gsl
+    qt510.qtbase
+    root
+    xercesc
+
+    # For now the upstream GEANT4 recipe is a little weird but it seems like someone is working on it:
+    # https://github.com/NixOS/nixpkgs/pull/40618
+    # As it is badly written it isn't available in the binary cache so this will trigger a build
+    geant4.v10_0_2
+  ];
+}

--- a/testdrive/nix/c7-nix/testdrive_environment.nix
+++ b/testdrive/nix/c7-nix/testdrive_environment.nix
@@ -2,74 +2,109 @@
 
 with import nixpkgs {};
 
-stdenv.mkDerivation rec {
-  name = "HSF_testdrive_environment";
-  env = buildEnv {
-    name = name;
-    paths = buildInputs;
-    extraOutputsToInstall = [
-      "bin" "debug" "dev" "devdoc" "doc" "info" "man" "out" "static"
+let
+  clhep = callPackage ./clhep.nix {};
+
+  # For now the upstream GEANT4 recipe is a little weird but it seems like someone is working on it:
+  # https://github.com/NixOS/nixpkgs/pull/40618
+  # As it is badly written it isn't available in the binary cache so this will trigger a build
+  # If we're forced to build to build, then we might as well enable everything
+  geant4Full = (geant4.override {
+    enableMultiThreading = true;
+    enableG3toG4 = true;
+    enableInventor = false;
+    enableGDML = true;
+    enableQT = true;
+    enableXM = true;
+    enableOpenGLX11 = true;
+    enableRaytracerX11 = true;
+
+    clhep = clhep;
+    zlib = zlib;
+    expat = expat;
+    xercesc = xercesc;
+    motif = motif;
+    qt = qt4;
+    xlibsWrapper = xlibsWrapper;
+    libXmu = xorg.libXmu;
+  }).v10_0_2;
+in
+  stdenv.mkDerivation rec {
+    name = "HSF_testdrive_environment";
+    env = buildEnv {
+      name = name;
+      paths = buildInputs;
+      ignoreCollisions = true;
+      extraOutputsToInstall = [
+        "bin" "debug" "dev" "devdoc" "doc" "info" "man" "out" "static"
+      ];
+    };
+    buildInputs = [
+      # Nix itself
+      nix
+      nix-prefetch-scripts
+
+      # Some base libraries
+      autoconf
+      automake
+      bash
+      bashInteractive
+      bzip2
+      cmake
+      coreutils
+      cpio
+      cracklib
+      curl
+      diffutils
+      ed
+      elfutils
+      emacs
+      expat
+      findutils
+      fish
+      gawk
+      gfortran
+      git
+      gnugrep
+      gnumake
+      gnused
+      gnutar
+      gzip
+      htop
+      less
+      man
+      patchelf
+      pcre
+      perl
+      procps
+      rsync
+      stdenv
+      strace
+      tcl
+      vim
+      wget
+      which
+      xz
+      zlib
+      zsh
+
+      ((python2.withPackages (ps: [
+          ps.pip
+          ps.ipython
+          ps.numpy
+          ps.matplotlib
+        ])).override {
+          # Workaround https://github.com/NixOS/nixpkgs/issues/22319
+          ignoreCollisions = true;
+      })
+
+      # The test drive packages
+      boost166
+      gsl
+      qt510.qtbase
+      root
+      xercesc
+      clhep
+      geant4Full
     ];
-  };
-  buildInputs = [
-    # Nix itself
-    nix
-
-    # Some base libraries
-    autoconf
-    automake
-    bash
-    bashInteractive
-    bzip2
-    cmake
-    coreutils
-    cpio
-    cracklib
-    curl
-    diffutils
-    ed
-    elfutils
-    emacs
-    expat
-    findutils
-    fish
-    gawk
-    gcc
-    git
-    gnugrep
-    gnumake
-    gnused
-    gnutar
-    gzip
-    htop
-    less
-    man
-    patchelf
-    pcre
-    perl
-    procps
-    python
-    rsync
-    stdenv
-    strace
-    tcl
-    vim
-    wget
-    which
-    xz
-    zlib
-    zsh
-
-    # The test drive packages
-    boost166
-    gsl
-    qt510.qtbase
-    root
-    xercesc
-
-    # For now the upstream GEANT4 recipe is a little weird but it seems like someone is working on it:
-    # https://github.com/NixOS/nixpkgs/pull/40618
-    # As it is badly written it isn't available in the binary cache so this will trigger a build
-    geant4.v10_0_2
-  ];
-}
+  }


### PR DESCRIPTION
This PR includes the list of test drive packages along with a significant fraction of packages included in HepOSLibs. A couple of notes:
 - CLHEP isn't included in the main repository so I've added an expression manually here as an example but this should be contributed to nixpkgs at some point.
 - The upstream GEANT4 expression isn't well written and this causes it to not exist in the binary cache. Someone has made an PR to update and improve it but I haven't used that here. As we have to build it anyway I've enabled most of the options as an example of how packages can be configured.
 - There are a few tweaks needed to allow setting the C++ standard for all packages, I have most of these patches for my LHCb test but I haven't included them here so the official binary caches can be used.
 - This hasn't really been tested but I'm happy to deal with bugs if people report them

I've uploaded the image to my dockerhub account you can try it using:
 1. The default command is set to launch `nix-shell`:
```bash
docker run --rm -it chrisburr/hsf:testdrive-c7-nix
```
 2. Alternatively you can run bash so you can edit the expression in before launching `nix-shell`: 
```bash
docker run --rm -it chrisburr/hsf:testdrive-c7-nix bash
# Edit /home/hsf/testdrive_environment.nix
nix-shell --pure --command 'export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt; return' /home/hsf/testdrive_environment.nix
```
